### PR TITLE
Changed padding strategy, pad by PSF size first then to next highest product of 2,3,57

### DIFF
--- a/examples/find_PSF_support.ipynb
+++ b/examples/find_PSF_support.ipynb
@@ -1,0 +1,390 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Find PSF support\n",
+    "\n",
+    "This is a short notebook to experiment with automatic detection of the size of the PSF support.\n",
+    "The background is that the input image should be padded by the size of the PSF in\n",
+    "order to avoid wrap-around artefacts. \n",
+    "Looking at the dimensions of the PSF volume is not helpful if the main support of the\n",
+    "PSF is small and there is a lot of padding around.\n",
+    "Also, for PSFs derived from bead images there may be a low level of noise or background\n",
+    "intensity surrounding the PSF.\n",
+    "\n",
+    "### Approach\n",
+    "\n",
+    "* find maximum value of PSF volume\n",
+    "* threshold image at a fixed fraction of the maximum (e.g. 5%)\n",
+    "* determine bounding box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import tifffile \n",
+    "from lls_dd.transform_helpers import get_projection_montage, plot_all\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psf = tifffile.imread(\"c:/Users/Volker/Data/Experiment_testing_stacks/PSF_Processed/488/PSF_488.tif\")\n",
+    "psf = np.squeeze(psf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALQAAAD8CAYAAADexo4zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAADa9JREFUeJzt3V+MXOV9xvHvs7P+QwHj2AFqYRSDsFpQ1ACyAoiqSnHTEDdKckElUNREkSX3gkREiZRCe1FV6kVzE2ikCtVKaElF/lAnUSILhTqGKOpFHKBQCBjIQtLEgeBQDCFNQuzdXy/OO7vj2fHs2d05O8e/fT7SaOa856znnJln33nPmfXvVURglsXEuHfAbJQcaEvFgbZUHGhLxYG2VBxoS6WRQEu6XtIzkqYk3drEc5gNolFfh5bUAZ4F3gkcAR4CboqIp0b6RGYDNNFDvx2YiojnI+K3wJeA9zXwPGbzTDbwb14A/KRn+Qhw1bAfWKt1sZ4zG9gVy+J1jr0cEecutF0TgdaAtnnjGkl7gD0A6/kdrtLOBnbFsvhW7PufOts1MeQ4AlzYs7wVeKF/o4jYGxE7ImLHGtY1sBu2GjUR6IeA7ZIukrQWuBH4RgPPYzbPyIccEXFC0keA+4EOcFdEPDnq5zEbpIkxNBFxH3BfE/+22TD+ptBScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJZMNCS7pJ0VNL3e9o2STog6Qfl/k2lXZI+U+pCPy7pyiZ33qxfnR76X4Hr+9puBQ5GxHbgYFkGeDewvdz2AHeOZjfN6lkw0BHxHeCVvub3AXeXx3cD7+9p/3xUvgtslLRlVDtrtpCljqHPj4gXAcr9eaV9UG3oCwb9A5L2SHpY0sPHeWOJu2F2slGfFNaqDQ0up2vNWGqgX+oOJcr90dJeqza0WVOWGuhvAB8qjz8EfL2n/YPlasfVwGvdoYnZSliwnK6kLwLvAN4s6Qjwt8A/APdK2g38GPjzsvl9wC5gCvgV8OEG9tnslBYMdETcdIpV8yZFiWqOuJuXu1NmS+VvCi0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUqlTTvdCSQ9KOizpSUm3lHaX1LXWqdNDnwA+ERGXAlcDN0u6DJfUtRaqU073xYj4r/L4deAwVUVRl9S11lnUGFrSNuAK4BAjKKlrNmq1Ay3pLOArwMci4hfDNh3QNq+krutDWxNqBVrSGqow3xMRXy3Nyyqp6/rQ1oQ6VzkEfA44HBGf7lnlkrrWOgtWHwWuBf4CeELSY6Xtr3FJXWuhOuV0/5PB42JwSV1rGX9TaKk40JaKAz2MNHdbys9mt9TXpkEO9DAR1Q0W/8bFwNns8ui+HhGtCrUDfSr9vU/3jWvRmzc2va9By14PB3qY3t5HmuuxW/Ym2hwHut9SPkpXW8Bnf7En5pZbwoHu1ztm7n3Tum29Pfagn1ktWjrscKBPpdtDx8zgdYN6pRb1VI0qv+yaUOuO2YEe5lRv1mo/OSyvS8y073zCgT4VCSY6oAnUOfneAKl6PdxDnx7U6dA560w6l2zjjZ2XM/HW7Uycs6H6mIXVOW7uKkOON677g+qXvkUc6EGkqic+Yz3P/uW53LX3Dp7+6NlMb98Knb43sGU91Ioo5xd37b1jbrklFC3YmQ3aFFdp3h/ujVf5SNUZZ1TLx48T0zPEieNz27TgtRunibPPZuaXv6wWGn4tvhX7HomIHQttV+fvoVenCGJ6Gn7962pxZhFvmNp39j9SZZgVvyn/da5Fx+ohR1f/WLiEMqanqzDHzOBLeIN+tkVvcJNienrcuzCPA93VH8Lebwr7g9y90qG+E8TVpvu6tOjE0IHu6v/ma0ivq04HTa6Z/3OrUcsuY7Zrb8apt5cd9Hj2K+/u3y/MVNdhe9etFr2/3BPtOnYHuqu/h+7/m47ekPe+if3Dj9WmZT20r3J0DeqV+8fG5c2L4yfK+lOcJGbX/SWf6Aw/WR4DB3qYAb1u70ds9J/kZ79c19X/p7WaGPBijIcDPcy8Kx/TbeqMxiuila9HncpJ6yV9T9J/l/rQf1faL5J0qNSH/rKktaV9XVmeKuu3NXsIZnPqjOjfAK6LiLcBlwPXlxJfnwJuL/WhjwG7y/a7gWMRcQlwe9nObEXUqQ8dEVG+sGdNuQVwHbCvtPfXh+7Wjd4H7Cz18cwaV7f6aKfUtTsKHACeA16NiHK6f1IN6Nn60GX9a8DmAf+my+nayNUKdERMR8TlVKVx3w5cOmizcl+rPrTL6VoTFnVVPCJeBb5NNdfKRkndqyS9NaBn60OX9ecAr4xiZ80WUucqx7mSNpbHZwB/QjXPyoPADWWz/vrQ3brRNwAPRBv+6NpWhTrXobcAd0vqUP0C3BsR+yU9BXxJ0t8Dj1IVRafc/5ukKaqe+cYG9ttsoDr1oR+nmiiov/15qvF0f/tvmCt+brai2vWXJWbL5EBbKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyq1A13q2z0qaX9Zdjlda53F9NC3UFVM6nI5XWudutVHtwJ/Bny2LAuX07UWqttD3wF8EuhOQLCZZZbTNWtCnWKN7wGORsQjvc0DNl1UOV3Xh7Ym1CnWeC3wXkm7gPXABqoee6OkydILDyqne2RYOd2I2AvsBdigTa5OaiNRZ0qK2yJia0Rso6ok+kBEfACX07UWWs516L8CPl7K5m7m5HK6m0v7x4Fbl7eLZvUtap7CiPg2VQV/l9O1VvI3hZaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlkrd6qM/kvSEpMckPVzaNkk6UOpDH5D0ptIuSZ8p9aEfl3Rlkwdg1msxPfQfR8TlEbGjLN8KHCz1oQ8yVyHp3cD2ctsD3DmqnTVbyHKGHL11oPvrQ38+Kt+lKuq4ZRnPY1Zb3UAH8B+SHpG0p7SdHxEvApT780r7bH3oord29CyX07Um1K1td21EvCDpPOCApKeHbFurPrTL6VoTavXQEfFCuT8KfI2qSONL3aFEuT9aNu/Wh+7qrR1t1qg6FfzPlHR29zHwp8D3ObkOdH996A+Wqx1XA691hyZmTasz5Dgf+FqZ92cS+EJEfFPSQ8C9knYDP2auhO59wC5gCvgV8OGR77XZKSwY6FIH+m0D2v8X2DmgPYCbR7J3ZovkbwotFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lKpW053o6R9kp6WdFjSNS6na21Ut4f+R+CbEfH7VDU6DuNyutZCdUqBbQD+CPgcQET8NiJexeV0rYXq9NAXAz8H/kXSo5I+W2rcLaucbutJc7f+9mHre7exFVcn0JPAlcCdEXEF8H/MDS8GqVVOt9X1oQeFuL8t4uT7QetsxdUJ9BHgSEQcKsv7qAK+rHK6EbE3InZExI41rFvq/o9Ob2BLINXp0LnkIu7/6aNM/u75aHJybtuJztzjYb21ragFAx0RPwN+Iun3StNO4CmyldPt7VVLMGN6mumpH/KuC67gxM9eIqan0eQa0ATqdFCnc/LPu2ceu7oV/D8K3CNpLfA8VYncCbKW0x0UzJ6Qz97PTK/kXlkNtQIdEY8BOwasWj3ldGfHzA5xm/mbQkvFgbZUHGhLxYG2VBxoS8WBtlQcaEvFgbZUHGhLxYG2VBxoS8WBtlQcaEvFgbZUHGhLxYG2VBxoS8WBtlQcaEvFgbZUHGhLxYG2VBxoS0XRgmo/kl4Hnhn3fozJm4GXx70TY7KYY39LRJy70EZ1Kyc17ZmIGFTIJj1JD/vYR8dDDkvFgbZU2hLovePegTHysY9QK04KzUalLT202UiMPdCSrpf0TJkGbthUF6clSRdKerBMh/ekpFtK+6qYFk9Sp8zNs78sXyTpUDnuL5ea40haV5anyvptS3m+sQZaUgf4J6qp4C4DbpJ02Tj3qQEngE9ExKXA1cDN5RhXy7R4t1BNA9j1KeD2ctzHgN2lfTdwLCIuAW4v2y1eRIztBlwD3N+zfBtw2zj3aQWO+evAO6m+SNpS2rZQXYsH+Gfgpp7tZ7c73W5U8+scBK4D9lNNKPUyMNn//gP3A9eUx5NlOy32Occ95MgxBVxN5WP0CuAQ2afFq9wBfBKYKcubgVcj4kRZ7j222eMu618r2y/KuANdawq4DCSdBXwF+FhE/GLYpgPaTrvXRNJ7gKMR8Uhv84BNo8a62sb91XetKeBOd5LWUIX5noj4aml+SdKWiHhxKdPinQauBd4raRewHthA1WNvlDRZeuHeY+se9xFJk8A5wCuLfdJx99APAdvLme9a4EaqaeHSkCSqaaUPR8Sne1blmhavT0TcFhFbI2Ib1fv6QER8AHgQuKFs1n/c3dfjhrL94j+ZWnDisAt4FngO+Jtx708Dx/eHVB+djwOPldsuqvHhQeAH5X5T2V5UV36eA54Adoz7GEbwGrwD2F8eXwx8j2rav38H1pX29WV5qqy/eCnP5W8KLZVxDznMRsqBtlQcaEvFgbZUHGhLxYG2VBxoS8WBtlT+H5cgC0B73veDAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x206a0689cc0>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_all([get_projection_montage(psf)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 168, 1, 512, 256)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "psf.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<function ndarray.max>"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "psf.max"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "maxpsf = psf.max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0004211425688554216"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "maxpsf * 0.05"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALQAAAD8CAYAAADexo4zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAADHtJREFUeJzt3VusXGUZxvH/Q0tbAUtpOaQFYiE0CjcUQjgEYxDEQiXgBSYQIoQ06Q2SEkgQ9MKYeCE3nBJDJIKCQQELBNIQaikQ4wWlrVRO5VCIQlOkIuVgiGDl9WJ9006n073X3nvWntnvPL9kMrO+WZ1Za/fZq9+saZ6liMAsi/36vQFmveRAWyoOtKXiQFsqDrSl4kBbKo0EWtJ5kl6TtEXSDU28h1k36vV5aEnTgNeBc4GtwHrg0oh4padvZNZFE0foU4EtEfFWRHwO3A9c1MD7mO1legOveSTwTtvyVuC0kf7ADM2MWRzYwKZYFp+w4/2IOGy09ZoItLqM7TWvkbQcWA4wiwM4Tec0sCmWxZOx8u911mtiyrEVOLpt+ShgW+dKEXFnRJwSEafsz8wGNsOGUROBXg8sknSMpBnAJcBjDbyP2V56PuWIiJ2SfgCsBqYBd0fEy71+H7NumphDExGPA4838dpmI/E3hZaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlsqogZZ0t6Ttkl5qG5sraY2kN8r9IWVckm4vvdAvSDq5yY0361TnCP0b4LyOsRuAtRGxCFhblgHOBxaV23Lgjt5splk9owY6Iv4EfNAxfBFwT3l8D/DdtvF7o/IsMEfS/F5trNloxjuHPiIi3gUo94eX8W7d0Ed2ewFJyyVtkLThv3w2zs0w21OvPxTW6oYG1+laM8Yb6PdaU4lyv72M1+qGNmvKeAP9GHBFeXwF8Gjb+OXlbMfpwEetqYnZZBi1TlfS74GzgEMlbQV+AvwceFDSMuBt4Htl9ceBpcAW4FPgyga22WyfRg10RFy6j6f2uihKVNeIu2qiG2U2Xv6m0FJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtlTp1ukdLelrSZkkvS1pRxl2pawOnzhF6J3BdRBwPnA5cJekEXKlrA6hOne67EfGX8vgTYDNVo6grdW3gjGkOLWkhcBKwjh5U6pr1Wu1ASzoIeAi4JiI+HmnVLmN7Veq6H9qaUCvQkvanCvN9EfFwGZ5Qpa77oa0Jdc5yCLgL2BwRN7c95UpdGzijto8CZwLfB16UtKmM/QhX6toAqlOn+2e6z4vBlbo2YPxNoaXiQFsqdebQ6azetoklCxZ3HR+vJQsW7/XnW+/RGu/2nlNRt5/ToOzbUAa6iaCN9MswKH/Zw2CopxxLFizeI9wTCV77n21/zdbNJsfQBrrJkLUf+X10nlxDG+jOoHWbA49Ft/lz6+g80de2+oYy0E2Hq/OXZaLTGatvKAPdHq72cE80dJ1zZ085Jt9QBhr2nOf26ojd+TrtwbbJMbSB7jwr0etpSOvo7Pnz5BraQLdrBa6XwXOI+8OBZvfRutdTA4d68jnQ0NNTa+2/HJ47T76h/Op7Xzq/Eh+PJqYvVp8DTTMfCru9vo/YzfOUo2gibA7w5BvqQLf/x6EmjtC9/NLG6hnqQLd/cGsqcA7y5BrqQEPzH+L830cn19AHuv0DYZNHaYd6cgx9oKE3p+tG4jMck8en7QoHrr5B/lnVaU6aJek5SX8t/dA/LePHSFpX+qEfkDSjjM8sy1vK8wub3QWz3epMOT4Dzo6IE4HFwHml4usm4JbSD70DWFbWXwbsiIjjgFvKemaTok4/dETEv8vi/uUWwNnAyjLe2Q/d6o1eCZxT+vHMGle3fXRa6bXbDqwB3gQ+jIidZZX2Duhd/dDl+Y+AeV1e03W61nO1Ah0R/4uIxVTVuKcCx3dbrdzX6od2na41YUyn7SLiQ+AZqmutzJHUOkvS3gG9qx+6PH8w8EEvNtZsNHXOchwmaU55/CXgW1TXWXkauLis1tkP3eqNvhh4qjSSmjWuznno+cA9kqZR/QI8GBGrJL0C3C/pZ8DzVKXolPvfStpCdWS+pIHtNuuqTj/0C1QXCuocf4tqPt05/h92l5+bTSp/9W2pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlkrtQJd+u+clrSrLrtO1gTOWI/QKqsakFtfp2sCp2z56FPAd4FdlWbhO1wZQ3SP0rcD1wBdleR4TrNM1a0KdssYLgO0RsbF9uMuqY6rTdT+0NaFOWeOZwIWSlgKzgNlUR+w5kqaXo3C3Ot2tI9XpRsSdwJ0AszXX7aTWE3UuSXFjRBwVEQupmkSfiojLcJ2uDaCJnIf+IXBtqc2dx551uvPK+LXADRPbRLP6xnSdwoh4hqrB33W6NpD8TaGl4kBbKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKVSt330b5JelLRJ0oYyNlfSmtIPvUbSIWVckm4v/dAvSDq5yR0wazeWI/Q3I2JxRJxSlm8A1pZ+6LXsbkg6H1hUbsuBO3q1sWajmciUo70HurMf+t6oPEtV6jh/Au9jVlvdQAfwR0kbJS0vY0dExLsA5f7wMr6rH7po747exXW61oS63XZnRsQ2SYcDayS9OsK6tfqhXadrTah1hI6IbeV+O/AIVUnje62pRLnfXlZv9UO3tHdHmzWqToP/gZK+3HoMfBt4iT17oDv7oS8vZztOBz5qTU3MmlZnynEE8Ei57s904HcR8YSk9cCDkpYBb7O7QvdxYCmwBfgUuLLnW222D6MGuvRAn9hl/F/AOV3GA7iqJ1tnNkb+ptBScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLRUH2lJxoC0VB9pScaAtFQfaUnGgLZW6dbpzJK2U9KqkzZLOcJ2uDaK6R+jbgCci4mtUHR2bcZ2uDaA6VWCzgW8AdwFExOcR8SGu07UBVKcK7Fjgn8CvJZ0IbARW0FGnW5pJYd91ulOq3271tk09fb0lCxb39PWsuzqBng6cDFwdEesk3cbu6UU3tep0S8/0coBZHFBjM5rnEE99dQK9FdgaEevK8kqqQL8naX45Oo+5TndQ+qEd4lxGnUNHxD+AdyR9tQydA7zCFK/T7RbkiYRxyYLFDvMAqNvgfzVwn6QZwFtUFbn7MUXrdFdv29Q1fGM9WjvAg0dV+21/zdbcOE17NfOa7fJkrNzYdgW2ffI3hZaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlspA9HJI+gR4rd/b0SeHAu/3eyP6ZCz7/pWIOGy0leo2JzXttTolIhlJ2uB97x1POSwVB9pSGZRA39nvDegj73sPDcSHQrNeGZQjtFlP9D3Qks6T9Fq5DNxIl7qYkiQdLenpcjm8lyWtKONDcVk8SdMkPS9pVVk+RtK6st8PlM5xJM0sy1vK8wvH8359DbSkacAvqC4FdwJwqaQT+rlNDdgJXBcRxwOnA1eVfRyWy+KtoLoMYMtNwC1lv3cAy8r4MmBHRBwH3FLWG7uI6NsNOANY3bZ8I3BjP7dpEvb5UeBcqi+S5pex+VTn4gF+CVzatv6u9abajer6OmuBs4FVVBeUeh+Y3vn3D6wGziiPp5f1NNb37PeUY1+XgEup/DN6ErCOjsviAaNdFm8quhW4HviiLM8DPoyInWW5fd927Xd5/qOy/pj0O9C1LgGXgaSDgIeAayLi45FW7TI25X4mki4AtkfExvbhLqtGjedq6/dX37UuATfVSdqfKsz3RcTDZXhCl8WbAs4ELpS0FJgFzKY6Ys+RNL0chdv3rbXfWyVNBw4GPhjrm/b7CL0eWFQ++c4ALqG6LFwakkR1WenNEXFz21NT+rJ4o4mIGyPiqIhYSPX3+lREXAY8DVxcVuvc79bP4+Ky/tj/ZRqADw5LgdeBN4Ef93t7Gti/r1P90/kCsKncllLND9cCb5T7uWV9UZ35eRN4ETil3/vQg5/BWcCq8vhY4Dmqy/79AZhZxmeV5S3l+WPH817+ptBS6feUw6ynHGhLxYG2VBxoS8WBtlQcaEvFgbZUHGhL5f+O9szO1ET74QAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x206a1c41cf8>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plotting a really small percentage shows which areas have been padded\n",
+    "plot_all([get_projection_montage(psf > maxpsf * 0.001)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALQAAAD8CAYAAADexo4zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAC5hJREFUeJzt3V+MVOUdxvHvI39bLSL4JyimaCSt3oiGKIamsVorUqO9oInEVGNIuMEGo4mF9qJp0gu9EWvSmBK11cZWLWo0hEgpYppeiGCl+AdRNK0SqNQKaGuqpf56cd6FcXfYPcvOYWZ/PJ9kMnPeOe68Z3k8e3Zm87yKCMyyOK7bEzDrJAfaUnGgLRUH2lJxoC0VB9pSaSTQkuZJ2i5ph6RlTbyGWTvq9PvQksYAbwBXADuBTcDCiHitoy9k1kYTZ+iLgB0R8XZEfAo8AlzbwOuYDTC2ga95BvBuy/ZO4OLB/oPxmhATOb6BqVgWH7H3/Yg4Zaj9mgi02owNuK6RtBhYDDCRL3KxLm9gKpbFH2LV3+rs18Qlx07gzJbt6cCu/jtFxMqImB0Rs8cxoYFp2LGoiUBvAmZKOkvSeOA64OkGXsdsgI5fckTEAUk3A2uBMcADEfFqp1/HrJ0mrqGJiDXAmia+ttlg/EmhpeJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKXiQFsqDrSlMmSgJT0gaY+kV1rGpkhaJ+nNcn9SGZeke0ov9FZJFzY5ebP+6pyhfwXM6ze2DFgfETOB9WUb4CpgZrktBu7tzDTN6hky0BHxR+CDfsPXAg+Wxw8C32kZfygqzwOTJU3r1GTNhnKk19CnRcRugHJ/ahlv1w19RrsvIGmxpM2SNv+XT45wGmaf1+lfCmt1Q4PrdK0ZRxro9/ouJcr9njJeqxvarClHGuingRvL4xuBp1rGbyjvdswB9vddmpgdDUPW6Ur6LXApcLKkncCPgTuAxyQtAt4Bvlt2XwPMB3YAHwM3NTBns8MaMtARsfAwTw1YFCWqNeKWjHRSZkfKnxRaKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyoOtKVSp073TEkbJG2T9KqkpWXclbrWc+qcoQ8At0XEucAcYImk83ClrvWgOnW6uyPiz+XxR8A2qkZRV+pazxnWNbSkGcAFwEY6UKlr1mm1Ay3pBOBx4JaI+HCwXduMDajUdT+0NaFWoCWNowrzwxHxRBkeUaWu+6GtCXXe5RBwP7AtIu5qecqVutZzhmwfBeYC3wNelrSljP0QV+paD6pTp/sn2l8Xgyt1rcf4k0JLxYG2VBxoS8WBtlQcaEvFgbZUHGhLxYG2VBxoS8WBtlQcaEulzh8nHbPW7toyYOzK02d1YSa9ae2uLT33/fAZ2lJxoAfReva58vRZPXc2soF8yTEEh/jwevF74zO0peJAWyoOtKXiQFsqDrSl4kBbKg60peJAWyp1mpMmSnpB0l9KP/RPyvhZkjaWfuhHJY0v4xPK9o7y/IxmD8HskDpn6E+AyyLifGAWMK9UfN0JrCj90HuBRWX/RcDeiDgHWFH2Mzsq6vRDR0T8q2yOK7cALgNWlfH+/dB9vdGrgMtLP55Z4+q2j44pvXZ7gHXAW8C+iDhQdmntgD7YD12e3w9MbfM1XadrHVcr0BHxv4iYRVWNexFwbrvdyn2tfmjX6VoThvUuR0TsA56jWmtlsqS+v9Zr7YA+2A9dnj8R+KATkzUbSp13OU6RNLk8/gLwTap1VjYAC8pu/fuh+3qjFwDPlkZSs8bV+XvoacCDksZQ/Q/wWESslvQa8IiknwIvUZWiU+5/LWkH1Zn5ugbmbdZWnX7orVQLBfUff5vqerr/+H84VH5udlT5k0JLxYG2VBxoS8WBtlQcaEvFgbZUHGhLxYG2VBxoS8WBtlQcaEvFgbZUHGhLxYG2VBxoS8WBtlQcaEvFgbZUHGhLxYG2VBxoS8WBtlRqB7r0270kaXXZdp2u9ZzhnKGXUjUm9XGdrvWcuu2j04FvA/eVbeE6XetBdc/QdwO3A5+V7amMsE7XrAl1yhqvBvZExIutw212HVadrvuhrQl1yhrnAtdImg9MBCZRnbEnSxpbzsLt6nR3DlanGxErgZUAkzTF7aTWEXWWpFgeEdMjYgZVk+izEXE9rtO1HjSS96F/ANxaanOn8vk63all/FZg2cimaFZfnUuOgyLiOaoGf9fpWk/yJ4WWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JZK3fbRv0p6WdIWSZvL2BRJ60o/9DpJJ5VxSbqn9ENvlXRhkwdg1mo4Z+hvRMSsiJhdtpcB60s/9HoONSRdBcwst8XAvZ2arNlQRnLJ0doD3b8f+qGoPE9V6jhtBK9jVlvdQAfwe0kvSlpcxk6LiN0A5f7UMn6wH7po7Y4+yHW61oS63XZzI2KXpFOBdZJeH2TfWv3QrtO1JtQ6Q0fErnK/B3iSqqTxvb5LiXK/p+ze1w/dp7U72qxRdRr8j5f0pb7HwLeAV/h8D3T/fugbyrsdc4D9fZcmZk2rc8lxGvBkWfdnLPCbiHhG0ibgMUmLgHc4VKG7BpgP7AA+Bm7q+KzNDmPIQJce6PPbjP8TuLzNeABLOjI7s2HyJ4WWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbanUrdOdLGmVpNclbZN0iet0rRfVPUP/DHgmIr5K1dGxDdfpWg+qUwU2Cfg6cD9ARHwaEftwna71oDpn6LOBfwC/lPSSpPtKx92I6nTNmlAn0GOBC4F7I+IC4N8curxop1adrvuhrQl1yhp3AjsjYmPZXkUV6PckTYuI3UdSpzta+qHX7tpy8PGVp8/q4kysjjpljX+X9K6kr0TEdqqCxtfK7UbgDgbW6d4s6RHgYkZ5na5DPLrUbfD/PvCwpPHA21QVucfhOl3rMbUCHRFbgNltnnKdrvUUf1JoqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pONCWigNtqTjQlooDbak40JaKA22pqKrR6PIkpI+A7d2eR5ecDLzf7Ul0yXCO/csRccpQO9VtTmra9ohoV2STnqTNPvbO8SWHpeJAWyq9EuiV3Z5AF/nYO6gnfik065ReOUObdUTXAy1pnqTtZRm4wZa6GJUknSlpQ1kO71VJS8v4MbEsnqQxZW2e1WX7LEkby3E/WjrHkTShbO8oz884ktfraqAljQF+TrUU3HnAQknndXNODTgA3BYR5wJzgCXlGI+VZfGWUi0D2OdOYEU57r3AojK+CNgbEecAK8p+wxcRXbsBlwBrW7aXA8u7OaejcMxPAVdQfZA0rYxNo3ovHuAXwMKW/Q/uN9puVOvrrAcuA1ZTLSj1PjC2/78/sBa4pDweW/bTcF+z25ccx9QScOXH6AXARo6NZfHuBm4HPivbU4F9EXGgbLce28HjLs/vL/sPS7cDXWsJuAwknQA8DtwSER8OtmubsVH3PZF0NbAnIl5sHW6za9R4rrZuf/Rdawm40U7SOKowPxwRT5ThES2LNwrMBa6RNB+YCEyiOmNPljS2nIVbj63vuHdKGgucCHww3Bft9hl6EzCz/OY7HriOalm4NCSJalnpbRFxV8tTT1MthwcDl8W7obzbMYdRuixeRCyPiOkRMYPq3/XZiLge2AAsKLv1P+6+78eCsv/wfzL1wC8O84E3gLeAH3V7Pg0c39eofnRuBbaU23yq68P1wJvlfkrZX1Tv/LwFvAzM7vYxdOB7cCmwujw+G3iBatm/3wETyvjEsr2jPH/2kbyWPym0VLp9yWHWUQ60peJAWyoOtKXiQFsqDrSl4kBbKg60pfJ/1tEp4ZCCYP4AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x206a1875390>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Something like three percent seems to give a good approximation\n",
+    "plot_all([get_projection_montage(psf > maxpsf * 0.03)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A closer look "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "a 1% threshold shows that there are some unwanted patches that we should probably remove from the PSF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALsAAAD8CAYAAAAvzdW+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAADJJJREFUeJzt3V2sHHUZx/Hvz75QAZtSBCyUWEwIwg1FTwDTxCiIIBrgAghIDDEkvREDkYQXrzTxAm58uTAmDaA1QQERIiHE2hSIN6ZSoCpQsYWgnLS2ykuKEIHC48XO0UPd053dmZ2d2ef3SZpzZs7smf/u/vbfZ2b3PKOIwCyDD0x6AGZNcdgtDYfd0nDYLQ2H3dJw2C0Nh93SqBR2SRdIek7SLkk31zUos3HQqG8qSVoE/AU4D5gFHgeujIhn6xueWX0WV7jtmcCuiHgBQNLdwMXAgmFfqsNiGUdU2KXZ+/2bN3g73lKZbauE/QTgpXnLs8BZh7rBMo7gLJ1bYZdm77c1tpTetkrY+72a/q8mkrQeWA+wjMMr7M6smioHqLPAifOWVwO7D94oIjZExExEzCzhsAq7M6umStgfB06WdJKkpcAVwIP1DMusfiOXMRFxQNK1wCZgEXBnRDxT28jMalalZiciHgYermksZmPld1AtDYfd0nDYLQ2H3dJw2C0Nh93ScNgtDYfd0nDYLQ2H3dJw2C0Nh93ScNgtDYfd0nDYLQ2H3dJw2C0Nh93SGBh2SXdK2ifp6XnrVkraLGln8fWo8Q7TrLoyM/tPgAsOWnczsCUiTga2FMtmrTYw7BHxW+CVg1ZfDGwsvt8IXFLzuMxqN2rNflxE7AEovh5b35DMxqNSK40y3P7O2mLUmX2vpFUAxdd9C23o9nfWFqOG/UHg6uL7q4Ff1TMcs/Epc+rx58DvgFMkzUq6BrgVOE/STnoXI7h1vMM0q25gzR4RVy7wIzdat07xO6iWhsNuaTjslobDbmk47JaGw25pOOyWxtg/G9M1m3Zv/+/35x+/doIjyWPuMR/34+2Z3dJw2C0NlzEHcenSvKYec8/slobDfgibdm9/3wGrjUdTj7PDbmk47JaGD1APwQerzfABqlnNHHZLY2AZI+lE4KfAR4D3gA0R8QNJK4F7gDXAi8DlEfHq+IY6umGO9Af9l7rQ73LJM7p+j+k4Hs8yM/sB4IaIOBU4G/iapNNwCzzrmDJ/cL0HmOv+9bqkHcAJ9FrgfabYbCPwGHDTWEY5QJ3naH1evRmTeJyHqtklrQHOALbiFnjWMaXDLulI4JfA9RGxf4jbrZe0TdK2d3hrlDGa1aLUeXZJS+gF/a6IuL9YvVfSqojYc6gWeBGxAdgAsFwro4YxA+0rNwYdZDX1me02m/RzVqYjmIA7gB0R8d15P3ILPOuUMjP7OuArwJ8kzb00v0mv5d29RTu8vwGXjWeIZvVQRG2VxUDLtTLO0vBd8yb9318dspYvdTx3h3rstsYW9scrKvN7/A6qpeGwWxqt/dTjNJQu1v+M1KR4Zrc0Jj6zT/rV3pSs59nb9Px6Zrc0HHZLY+JlTJsOYGy6eWa3NBx2S2PiZUwW2c7CtJFndkvDYbc0HPaGuG/k5DnslsbED1CzzHY+QJ08z+yWhsNuaUy8jPHHBawpZboLLJP0e0l/kPSMpG8X60+StFXSTkn3SFo6/uGaja5MGfMWcE5EnA6sBS6QdDZwG/C9otfjq8A14xumWXVlej0G8K9icUnxL4BzgC8X6zcC3wJ+VGUw01bS+AxMu57TUgeokhYVPWP2AZuB54HXIuJAscksvWan/W7r9nfWCqUOUCPiXWCtpBXAA8Cp/TZb4LYjtb9r04xg02GoU48R8Rq91tRnAyskzb1YVgO76x2aWb3KnI05ppjRkfRB4HPADuBR4NJiM/d6tNYrU8asAjZKWkTvxXFvRDwk6VngbknfAZ6i1/x0LPod6E2qtFmovPLBaL3G8XiWORvzR3oXIDh4/QvAmbWPyGxM/HEBS2PiHxcY1aBywmdw2meYM2zjKBE9s1saDrul0dkyZr6qb0ANuv1C/436DMz4TOqiv2ZToROXmamqqcuF22iqdDj2ZWbM+nDYLY2pOEAdpA0lS9aLEbSJZ3ZLw2G3NFKUMf2M6xOLC/1ely/D8ccFzCpw2C2NFG8q2fTym0pmfTjslkbpsBe9Y56S9FCx7PZ31inDzOzX0esqMMft76xTynYEWw18Ebi9WBa99nf3FZtsBC4ZxwDN6lJ2Zv8+cCPwXrF8NG5/Zx1TpknSl4B9EfHE/NV9Nl2w/V1EzETEzBIOG3GYZtWV+bjAOuAiSRcCy4Dl9Gb6FZIWF7O7299Z6w2c2SPilohYHRFrgCuARyLiKtz+zjqmygfBbqKh9nfTxC3zqjn4TyzPPP/N0rcdKuwR8Ri9Lr5uf2ed43dQLQ2H3Trl/OPXjlz+OeyWhsNuaTjslobDbmk47JZG2u4CTfAFEepX5TH1zG5pOOyWhsNuaTjsloYPUMeo6uVvrF6e2S0Nh93ScBkzRi5d2sUzu6XhsFsapcoYSS8CrwPvAgciYkbSSuAeYA3wInB5RLw6nmFaZnWVg8PM7J+NiLURMVMs3wxsKdrfbSmWzVqrVH/2YmafiYh/zlv3HPCZiNgjaRXwWESccqjf4/7sVrdx9GcP4DeSnpC0vlh3XETsASi+Hjv8UM2aU/bU47qI2C3pWGCzpD+X3UHx4lgPsIzDRxiiWT1KzewRsbv4ug94gF6/mL1F+ULxdd8Ct3WvR2uFMo1Nj5D0obnvgc8DTwMP0mt7B25/Zx1Qpow5Dnig15KdxcDPIuLXkh4H7pV0DfA34LLxDdOsuoFhL9rcnd5n/cuAT61YZ/gdVEvDYbc0HHZLw2G3NBx2S8NhtzQcdkvDYbc0HHZLw2G3NBx2S8NhtzQcdkvDYbc0HHZLw2G3NBx2S8NhtzRKhV3SCkn3SfqzpB2SPiVppaTNknYWX48a92DNqig7s/8A+HVEfJze36PuwO3vrGPKtNJYDnwauAMgIt6OiNeAi4GNxWYbgUvGNUizOpSZ2T8G/AP4saSnJN1e9I9x+zvrlDJhXwx8AvhRRJwBvMEQJYuk9ZK2Sdr2Dm+NOEyz6sqEfRaYjYitxfJ99MLv9nfWKQPDHhF/B16SNNeO+lzgWdz+zjqmbBffrwN3SVoKvAB8ld4Lxe3vrDNKhT0itgMzfX7k9nfWGX4H1dJw2C0Nh93ScNgtDYfd0nDYLQ2H3dJw2C0Nh93ScNgtDYfd0nDYLQ2H3dJw2C0Nh93ScNgtDYfd0nDYLY0yTZJOkbR93r/9kq53+zvrmjLdBZ6LiLURsRb4JPAm8ABuf2cdM2wZcy7wfET8Fbe/s44ZNuxXAD8vvnf7O+uU0mEvesZcBPximB24/Z21RdkmSQBfAJ6MiL3F8l5JqyJiz6D2d8AGgOVaGZVG2wKbdm8f6XbnH7+25pHYsIYpY67kfyUMuP2ddUzZK28cDpwH3D9v9a3AeZJ2Fj+7tf7hmdWnbPu7N4GjD1r3Mi1pfze/tJgrF/qtO3h9k+b263JmcvwOqqXhsFsaw5yNaZWFypRB206Ky5fJ88xuaTjslkYnyphBZUgbypR++p0FcjkzOZ7ZLY1WzextnaEXMsws7Rl98jyzWxoOu6Ux8TKmDaXLqCXGMB9TsMnzzG5pOOyWhiKa+3uK5VoZZ6kVH5ScGJc59doaW9gfr6jMtp7ZLQ2H3dKY+NmYLNpw1ik7z+yWhmf2MfJs3i6e2S0Nh93SaPQ8u6R/AG8A/2xsp836MNN539p8vz4aEceU2bDRsANI2hYRM43utCHTet+m5X65jLE0HHZLYxJh3zCBfTZlWu/bVNyvxmt2s0lxGWNpNBp2SRdIek7SLkmdvQaTpBMlPSpph6RnJF1XrJ+Ki6pJWiTpKUkPFcsnSdpa3K97igtTdE5jYZe0CPghvYsanAZcKem0pvZfswPADRFxKnA28LXivkzLRdWuA3bMW74N+F5xv14FrpnIqCpqcmY/E9gVES9ExNvA3fQuQtY5EbEnIp4svn+dXjBOYAouqiZpNfBF4PZiWcA5wH3FJp28X9Bs2E8AXpq3PFus6zRJa4AzgK1Mx0XVvg/cCLxXLB8NvBYRB4rlzj5vTYa9359OdfpUkKQjgV8C10fE/kmPpypJXwL2RcQT81f32bSTz1uTH/GdBU6ct7wa2N3g/mslaQm9oN8VEXOX3yl1UbUWWwdcJOlCYBmwnN5Mv0LS4mJ27+zz1uTM/jhwcnFkv5TeNVUfbHD/tSnq2DuAHRHx3Xk/6vRF1SLilohYHRFr6D0/j0TEVcCjwKXFZp27X3MaC3sxK1wLbKJ3QHdvRDzT1P5rtg74CnCOpO3FvwuZ3ouq3QR8Q9IuejX8HRMez0j8Dqql4XdQLQ2H3dJw2C0Nh93ScNgtDYfd0nDYLQ2H3dL4D1BYFwHfjFP2AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x206a1cbad30>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_all([get_projection_montage(psf[70:90, 230:280, 115:140] > maxpsf * 0.01)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAALsAAAD8CAYAAAAvzdW+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAC3BJREFUeJzt3V+MVPUZxvHvU/5I1RLEqlEgRRNj9aJiu1EbkiaFUqk26oU2UmtMQ8KNNhhN/NOrtld4o/aiMSFiy4VVKUpKjJESxDRNGgoKbcXVgsTqBgpWJVhNUfTtxfxoF7rrnt05Mztn3ueTbGbOmTOe33GeffnNOdn3KCIwy+Bzkz0As25x2C0Nh93ScNgtDYfd0nDYLQ2H3dJoK+ySlkp6TdJeSffWNSizTtBELypJmgL8DVgCDAHbgWUR8Up9wzOrz9Q23ns5sDci9gFIegK4Dhg17NN1SszgtDZ2aXaif/MBH8VRVdm2nbDPAd4atjwEXPFZb5jBaVyhxW3s0uxE22JL5W3bCftIv03/NyeStAJYATCDU9vYnVl72vmCOgTMG7Y8F9h/8kYRsToiBiJiYBqntLE7s/a0E/btwIWSzpc0HbgJ2FjPsMzqN+FpTEQck3Q7sAmYAjwaEbtrG5lZzdqZsxMRzwLP1jQWs47yFVRLw2G3NBx2S8NhtzQcdkvDYbc0HHZLw2G3NBx2S8NhtzQcdkvDYbc0HHZLw2G3NBx2S8NhtzQcdkvDYbc0xgy7pEclHZL08rB1syVtlrSnPJ7R2WGata9KZf8VsPSkdfcCWyLiQmBLWTbraWOGPSJ+D7x70urrgLXl+Vrg+prHZVa7ic7Zz4mIAwDl8ez6hmTWGW210qjC7e+sV0y0sh+UdC5AeTw02oZuf2e9YqJh3wjcWp7fCvy2nuGYdU6VU4+PA38ELpI0JGk5sApYImkPrZsRrOrsMM3aN+acPSKWjfKSG61bo/gKqqXhsFsaDrul4bBbGg67peGwWxoOu6XhsFsaDrul4bBbGg67peGwWxoOu6XhsFsaDrul4bBbGg67peGwWxpV/gZ1nqStkgYl7Za0sqx3CzxrlCqV/RhwV0RcDFwJ3CbpEtwCzxqmSvu7AxHxUnn+PjAIzMEt8KxhxjVnlzQfuAzYhlvgWcNUDruk04GngDsi4sg43rdC0g5JOz7m6ETGaFaLSmGXNI1W0B+LiKfL6kot8Nz+znpFlbMxAtYAgxHxwLCX3ALPGqVKF9+FwC3AXyXtKut+TKvl3brSDu9N4MbODNGsHlXa3/0B0Cgv91wLvE37d429EXDVeQs6PBIbr+GfXSc+H19BtTQcdkuj43feqFPVKUon/1ue/tRjrP//nZjSuLJbGo2o7HVW9HaNNRZX/tFN9ufoym5pOOyWRs9OYyb7nzzrP67slobDbmn07DSmqTp9ydsmzpXd0nDYLQ1PY6yjeumsmiu7pdGzlX34l7teqg5j8ZfSE/XS5+jKbmk47JaGw25pVOkuMEPSnyT9ufR6/GlZf76kbaXX45OSpnd+uGYTV6WyHwUWRcSlwAJgqaQrgfuBB0uvx/eA5Z0bpln7qnQXCOBfZXFa+QlgEfD9sn4t8BPg4fqHOPYZjm5+y/fZlomb7DMzVTuCTSk9Yw4Bm4HXgcMRcaxsMkSr2elI73X7O+sJlc6zR8QnwAJJs4ANwMUjbTbKe1cDqwFmavaI27RrpGrrP6jubWNV+UnvGxMRh4EXaPVpnyXp+C/LXGB/vUMzq1eVszFnlYqOpM8D36LVo30rcEPZzL0ereep9f3zMzaQvkLrC+gUWr8c6yLiZ5IuAJ4AZgM7gR9ExGdOymdqdlyhnuuYZw22LbZwJN4drT3jCaqcjfkLrRsQnLx+H3D5+IdnNjl8BdXScNgtDYfd0nDYLQ2H3dJw2C0Nh93ScNgtDYfd0nDYLQ2H3dJw2C0Nh93ScNgtDYfd0nDYLQ2H3dJw2C2NymEvvWN2SnqmLLv9nTXKeCr7SlpdBY5z+ztrlKodweYC1wCPlGXRan+3vmyyFri+EwM0q0vVyv4QcDfwaVk+E7e/s4ap0iTpu8ChiHhx+OoRNh21/V1EDETEwDROmeAwzdpXpdfjQuBaSVcDM4CZtCr9LElTS3V3+zvreWNW9oi4LyLmRsR84Cbg+Yi4Gbe/s4Zp5zz7PcCdkvbSmsOvqWdIZp0xrltDRsQLtLr4uv2dNY6voFoaDrul4bBbGg67peGwWxoOu6XhsFsaDrul4bBbGg67peGwWxoOu6XhsFsaDrul4bBbGg67peGwWxoOu6VR6c/yJL0BvA98AhyLiAFJs4EngfnAG8D3IuK9zgzTrH3jqezfjIgFETFQlu8FtpT2d1vKslnPamcacx2ttnfg9nfWAFXDHsDvJL0oaUVZd05EHAAoj2d3YoBmdanaSmNhROyXdDawWdKrVXdQfjlWAMzg1AkM0awelSp7ROwvj4eADbT6xRyUdC5AeTw0ynvd69F6QpXGpqdJ+sLx58C3gZeBjbTa3oHb31kDVJnGnANsaLVkZyrw64h4TtJ2YJ2k5cCbwI2dG6ZZ+8YMe2lzd+kI698BFndiUGad4CuolobDbmk47JaGw25pOOyWhsNuaTjslobDbmk47JaGw25pOOyWhsNuaTjslobDbmk47JaGw25pOOyWhsNuaVQKu6RZktZLelXSoKSvS5otabOkPeXxjE4P1qwdVSv7z4HnIuLLtP4edRC3v7OGqdJKYybwDWANQER8FBGHcfs7a5gqlf0C4G3gl5J2Snqk9I9x+ztrlCphnwp8FXg4Ii4DPmAcUxZJKyTtkLTjY45OcJhm7asS9iFgKCK2leX1tMLv9nfWKGOGPSL+Abwl6aKyajHwCm5/Zw1TtYvvj4DHJE0H9gE/pPWL4vZ31hiVwh4Ru4CBEV5y+ztrDF9BtTQcdkvDYbc0HHZLw2G3NBx2S8NhtzQcdkvDYbc0HHZLw2G3NBx2S8NhtzQcdkvDYbc0HHZLw2G3NBx2S6NKk6SLJO0a9nNE0h1uf2dNU6W7wGsRsSAiFgBfAz4ENuD2d9Yw453GLAZej4i/4/Z31jDjDftNwOPludvfWaNUDnvpGXMt8Jvx7MDt76xXVG2SBPAd4KWIOFiWD0o6NyIOjNX+DlgNMFOzo63RNsCm/bv++/yq8xZM4kjsZOOZxizjf1MYcPs7a5iqd944FVgCPD1s9SpgiaQ95bVV9Q/PrD5V2999CJx50rp36MP2d8OnIdZffAXV0nDYLY3xnI3pC52apvjMS+9zZbc0HHZLo++mMZ0+m+LpSnO5slsajars3T4H7ireX1zZLQ2H3dLo2WmMz4db3VzZLQ2H3dLo2WmMpxtWN1d2S8NhtzQcdkvDYbc0HHZLw2G3NBx2S0MR3etbJOlt4APgn13baXd9kf48tl4+ri9FxFlVNuxq2AEk7YiIga7utEv69dj65bg8jbE0HHZLYzLCvnoS9tkt/XpsfXFcXZ+zm00WT2Msja6GXdJSSa9J2iupsfdgkjRP0lZJg5J2S1pZ1vfFTdUkTZG0U9IzZfl8SdvKcT1ZbkzROF0Lu6QpwC9o3dTgEmCZpEu6tf+aHQPuioiLgSuB28qx9MtN1VYCg8OW7wceLMf1HrB8UkbVpm5W9suBvRGxLyI+Ap6gdROyxomIAxHxUnn+Pq1gzKEPbqomaS5wDfBIWRawCFhfNmnkcUF3wz4HeGvY8lBZ12iS5gOXAdvoj5uqPQTcDXxals8EDkfEsbLc2M+tm2HXCOsafSpI0unAU8AdEXFkssfTLknfBQ5FxIvDV4+waSM/t27+DeoQMG/Y8lxgfxf3XytJ02gF/bGIOH77nUo3VethC4FrJV0NzABm0qr0syRNLdW9sZ9bNyv7duDC8s1+Oq17qm7s4v5rU+axa4DBiHhg2EuNvqlaRNwXEXMjYj6tz+f5iLgZ2ArcUDZr3HEd17Wwl6pwO7CJ1he6dRGxu1v7r9lC4BZgkaRd5edq+vemavcAd0raS2sOv2aSxzMhvoJqafgKqqXhsFsaDrul4bBbGg67peGwWxoOu6XhsFsa/wGGf1+1ZOr9xwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x206a1d37080>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_all([get_projection_montage(psf[70:90, 230:280, 115:140] > maxpsf * 0.03)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 81, 252, 119], dtype=int64)"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.min(np.where(psf > maxpsf * 0.03), axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 86, 261, 136], dtype=int64)"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.max(np.where(psf > maxpsf * 0.03), axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 5,  9, 17], dtype=int64)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.max(np.where(psf > maxpsf * 0.03), axis=1) - np.min(np.where(psf > maxpsf * 0.03), axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 6, 10, 18], dtype=int64)"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# actual size is +1 (otherwise we have a fencepost error)\n",
+    "np.max(np.where(psf > maxpsf * 0.03), axis=1) - np.min(np.where(psf > maxpsf * 0.03), axis=1) + np.array([1,1,1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# put everything in a function\n",
+    "\n",
+    "def find_PSF_support(psf_vol, threshold_percentage = 0.03):\n",
+    "    \"\"\"find the size of the PSF as the bounding box of the area that is above a fraction of the max intensity\"\"\"\n",
+    "    maxval = psf_vol.max()\n",
+    "    mask = psf > maxval * threshold_percentage\n",
+    "    locations = np.where(mask)\n",
+    "    tmp = np.max(locations, axis=1) - np.min(locations, axis=1)\n",
+    "    support_size = tmp + np.array([1, 1, 1]) # add one to avoid fencepost error\n",
+    "    return support_size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 6, 10, 18], dtype=int64)"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "find_PSF_support(psf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/lls_dd/deconv_gputools_rewrite.py
+++ b/lls_dd/deconv_gputools_rewrite.py
@@ -101,7 +101,7 @@ class Deconvolver_RL_gputools(object):
 ## below are simple wrappers to make the interface compatible with the functions
 ## that were originally written for deconvolution with flowdec
 ## eventually all of those should be refactured into a classs
-def init_rl_deconvolver():
+def init_rl_deconvolver(**kwargs):
     """ dummy, nothing to initialiaze for the gputools deconv
     Note: maybe one can setup and keep the fft plan, this may require
     changes to gputools code.

--- a/lls_dd/deconvolution.py
+++ b/lls_dd/deconvolution.py
@@ -6,15 +6,17 @@ import numpy as np
 import warnings
 from typing import Optional, Callable
 import os
+import logging
 
+logger = logging.getLogger("lls_dd")
 # suppress tensorflow diagnostic output
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
 
-def init_rl_deconvolver():
+def init_rl_deconvolver(**kwargs):
     """initializes the tensorflow-based Richardson Lucy Deconvolver """
     return tfd_restoration.RichardsonLucyDeconvolver(
-        n_dims=3, start_mode="input", pad_mode="2357"
+        n_dims=3, start_mode="input", **kwargs 
     ).initialize()
 
 
@@ -48,17 +50,18 @@ def deconv_volume(
     np.ndarray
         deconvolved volume
     """
-    # TODO: this is a quick test whether tensorflow session configs can be used to limit the memory use
-    # if it works, add an option to pass in a tensorflow session config.
-    gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.85)
+    # TODO: test different gpu options and remove comments
+    #gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=0.85)
+    gpu_options = tf.GPUOptions(allow_growth = True)
     config = tf.ConfigProto(log_device_placement=False, gpu_options=gpu_options)
-    config.gpu_options.allow_growth = True
+    #config.gpu_options.allow_growth = True
 
     aq = fd_data.Acquisition(data=vol, kernel=psf)
     if observer is not None:
         warnings.warn("Observer function for iteration not yet implemented.")
-    return deconvolver.run(aq, niter=n_iter, session_config=config).data
-
+    result = deconvolver.run(aq, niter=n_iter, session_config=config)
+    logger.debug(f"flowdec info: {result.info}")
+    return result.data
 
 def get_deconv_function(
     psf: np.ndarray, deconvolver: tfd_restoration.RichardsonLucyDeconvolver, n_iter: int

--- a/lls_dd/deconvolution.py
+++ b/lls_dd/deconvolution.py
@@ -14,7 +14,7 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 def init_rl_deconvolver():
     """initializes the tensorflow-based Richardson Lucy Deconvolver """
     return tfd_restoration.RichardsonLucyDeconvolver(
-        n_dims=3, start_mode="input"
+        n_dims=3, start_mode="input", pad_mode="2357"
     ).initialize()
 
 

--- a/lls_dd/imsave.py
+++ b/lls_dd/imsave.py
@@ -50,6 +50,7 @@ THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 
 logger = logging.getLogger('lls_dd')
 
+
 def reorderstack(arr: np.ndarray, inorder: str = "zyx", outorder: str = "tzcyx"):
     """rearrange order of array, used when resaving a file for Fiji."""
     inorder = inorder.lower()
@@ -64,7 +65,9 @@ def reorderstack(arr: np.ndarray, inorder: str = "zyx", outorder: str = "tzcyx")
     arr = np.transpose(arr, [inorder.find(n) for n in outorder])
     return arr
 
-
+# TODO: I copied this in from Talley's LLSPy with the intention of writing the scale,
+# however, I don't like the stack reordering introducing additional length 1 dimensions
+# as I can't open a whole folder of 5 dim .tif files in spimage.
 def imsave(
     outpath: str,
     arr: np.array,

--- a/lls_dd/psf_tools.py
+++ b/lls_dd/psf_tools.py
@@ -111,6 +111,28 @@ def psf_normalize_intensity(psf: np.ndarray) -> np.ndarray:
         return psf
 
 
+def psf_find_support_size(psf: np.ndarray, threshold_fraction: float = 0.03) -> np.array:
+    """returns the dimensions of the bounding volume where the PSF is above a fraction of the max intensity
+    
+    Parameters
+    ----------
+    psf : np.ndarray
+        input volume
+    threshold_fraction : float, optional
+        fraction of maximum intensity to uses as threshold (the default is 0.03)
+    
+    Returns
+    -------
+    np.array
+        extent of the bounding volume dimensions
+    """
+    maxval = np.max(psf)
+    mask = psf > maxval * threshold_fraction
+    locations = np.where(mask)
+    tmp = np.max(locations, axis=1) - np.min(locations, axis=1)
+    support_size = tmp + np.array([1, 1, 1]) # add one to avoid fencepost error
+    return support_size
+
 def generate_psf(psffile: Union[pathlib.Path, str],
                  output_shape: Collection[int],
                  dz_stage: float,

--- a/lls_dd/utils.py
+++ b/lls_dd/utils.py
@@ -3,14 +3,10 @@ import warnings
 import logging
 import numpy as np
 from typing import Union
-
+import tifffile
 from lls_dd.imsave import imsave
 
 logging.getLogger("tifffile").setLevel(logging.ERROR)
-
-# write in a separate thread
-# https://www.geeksforgeeks.org/writing-files-background-python/
-
 
 def write_tiff_createfolder(
     path: Union[str, pathlib.Path], nparray: np.ndarray, **opt_kwargs
@@ -28,4 +24,5 @@ def write_tiff_createfolder(
     path.parent.mkdir(parents=True, exist_ok=True)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        imsave(str(path), nparray, **opt_kwargs)
+        tifffile.imsave(str(path), nparray)
+        #imsave(str(path), nparray, **opt_kwargs) # 


### PR DESCRIPTION
With this branch I changed the padding strategy to address GPU memory wastage and wrap-around artefacts.

For background see the dicussions here: 
https://github.com/VolkerH/Lattice_Lightsheet_Deskew_Deconv/issues/31

New padding approach:

* width of the support of the PSF is calculated for each wavelength and the maximum along each spatial dimension is taken as the minimum padding value for that dimension (passed to flowdec as `pad_min`)
* the resulting shape is padded to the next product of factors 2,3,5,7 along each dimension. This is done via changes introduced to flowdec in this branch https://github.com/VolkerH/flowdec/tree/padcufft which are not present in the upstream flowdec repo (pull request pending)