### PR TITLE
Deconwithoutdeskew

### DIFF
--- a/lls_dd/process_llsm_experiment.py
+++ b/lls_dd/process_llsm_experiment.py
@@ -253,7 +253,7 @@ class ExperimentProcessor(object):
 
         outfiles = self.generate_outputnames(infile)
         # Check wether anything needs to be processed? Return otherwise.
-        checks = [False, False, False, False]
+        checks = [False, False, False, False, False]
         if self.skip_existing:
             checks = []
             checks.append(self.do_deskew and outfiles["deskew"].exists())

--- a/lls_dd/process_llsm_experiment.py
+++ b/lls_dd/process_llsm_experiment.py
@@ -160,6 +160,7 @@ class ExperimentProcessor(object):
         )  # TODO: implement plain deconvolution on raw or remove
         outfiles["deconv/deskew"] = out_base / "py_deconv" / "deskew" / f"{stem}_deconv_deskew{suffix}"
         outfiles["deconv/rotate"] = out_base / "py_deconv" / "rotate" / f"{stem}_deconv_rotate{suffix}"
+        outfiles["deconv/plain"] = out_base / "py_deconv" / "plain" / f"{stem}_deconv{suffix}"
         # Maximum intensity projections ...
         outfiles["deskew/MIP"] = out_base / "py_deskew" / "MIP" / f"{stem}_deskew_MIP{suffix}"
         outfiles["rotate/MIP"] = out_base / "py_rotate" / "MIP" / f"{stem}_rotate_MIP{suffix}"
@@ -259,6 +260,8 @@ class ExperimentProcessor(object):
             checks.append(self.do_rotate and outfiles["rotate"].exists())
             checks.append(self.do_deconv_deskew and outfiles["deconv/deskew"].exists())
             checks.append(self.do_deconv_rotate and outfiles["deconv/rotate"].exists())
+            checks.append(not self.do_deconv_rotate and not self.do_deconv_deskew and outfiles["deconv/plain"].exists())
+
         if all(checks):
             if self.verbose:
                 warnings.warn(
@@ -315,6 +318,10 @@ class ExperimentProcessor(object):
                     self.create_MIP(
                         deconv_rotated.astype(self.output_dtype), outfiles["deconv/rotate/MIP"]
                     )
+            if not self.do_deconv_deskew and not self.do_deconv_rotate and not checks[4]:
+                print("writing plain deconvolved file")
+                write_func(outfiles["deconv/plain"], deconv_raw.astype(self.output_dtype))
+
 
     def process_stack_subfolder(self, stack_name: str, write_func: Callable = write_tiff_createfolder):
         """Process all files in a "Stack" folder of an Experiment folder

--- a/lls_dd/process_llsm_experiment.py
+++ b/lls_dd/process_llsm_experiment.py
@@ -319,7 +319,6 @@ class ExperimentProcessor(object):
                         deconv_rotated.astype(self.output_dtype), outfiles["deconv/rotate/MIP"]
                     )
             if not self.do_deconv_deskew and not self.do_deconv_rotate and not checks[4]:
-                print("writing plain deconvolved file")
                 write_func(outfiles["deconv/plain"], deconv_raw.astype(self.output_dtype))
 
 


### PR DESCRIPTION
Introduced new behaviour:

if a number of iterations for deconvolution is specified on the command line but neither the `--decon-rot` or `--decon-deskew` options are selected, the raw (plain) deconvolved volume will be stored. This is useful when using a viewer that can deskew on the fly.

